### PR TITLE
add dispose to StatefulWidget

### DIFF
--- a/lib/src/widgets/framework.dart
+++ b/lib/src/widgets/framework.dart
@@ -364,6 +364,8 @@ class $State$bridge<T extends StatefulWidget> extends State<T> with $Bridge<Stat
             ])),
         'initState': BridgeMethodDef(
             BridgeFunctionDef(returns: BridgeTypeAnnotation(BridgeTypeRef.type(RuntimeTypes.voidType)))),
+        'dispose': BridgeMethodDef(
+            BridgeFunctionDef(returns: BridgeTypeAnnotation(BridgeTypeRef.type(RuntimeTypes.voidType)))),
         'build': BridgeMethodDef(BridgeFunctionDef(
             returns: BridgeTypeAnnotation($Widget.$type),
             params: [BridgeParameter('context', BridgeTypeAnnotation($BuildContext.$type), false)])),
@@ -394,6 +396,11 @@ class $State$bridge<T extends StatefulWidget> extends State<T> with $Bridge<Stat
           super.initState();
           return null;
         });
+      case 'dispose':
+        return $Function((runtime, target, args) {
+          super.dispose();
+          return null;
+        });
       case 'widget':
         if (super.widget is $Instance) {
           return super.widget as $Instance;
@@ -412,6 +419,10 @@ class $State$bridge<T extends StatefulWidget> extends State<T> with $Bridge<Stat
   @override
   // ignore: must_call_super
   void initState() => $_invoke('initState', []);
+
+  @override
+  // ignore: must_call_super
+  void dispose() => $_invoke('dispose', []);
 
   @override
   Widget build(BuildContext context) => $_invoke('build', [$BuildContext.wrap(context)]);


### PR DESCRIPTION
I noticed that StatefulWidget currently lacks a bridge for the dispose method, so I tried to add that.

I found that in addition to modifying the code in flutter_eval, I also need to modify flutter_eval.json to add the dispose declaration structure to the json, otherwise the dart_eval compile compiler will report an error that the symbol is not found.

I can't find flutter_eval.json in flutter_eval, I guess it's probably generated automatically at release time.