### PR TITLE
Separate Flutter bindings generation from tests

### DIFF
--- a/.github/workflows/generate_bindings.yaml
+++ b/.github/workflows/generate_bindings.yaml
@@ -1,0 +1,19 @@
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  generate_bindings:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: 'stable'
+      - run: make flutter_bindings
+      - name: Archive generated flutter_eval.json
+        uses: actions/upload-artifact@v4
+        with:
+          name: flutter_eval.json
+          path: flutter_eval.json

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+.PHONY: flutter_bindings
+flutter_bindings:
+	flutter pub get
+	flutter test tool/generate_bindings.dart || true

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  dart_eval: ^0.6.0
+  dart_eval: ^0.7.8
   flutter_eval:
     path: ../
 

--- a/examples/code_push_app/pubspec.yaml
+++ b/examples/code_push_app/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
     sdk: flutter
   flutter_eval:
     path: ../../
-  dart_eval: ^0.6.0
+  dart_eval: ^0.7.8
 dev_dependencies:
   flutter_lints: ^2.0.0
 flutter:

--- a/test/flutter_eval_test.dart
+++ b/test/flutter_eval_test.dart
@@ -1,6 +1,3 @@
-import 'dart:convert';
-import 'dart:io';
-
 import 'package:dart_eval/dart_eval.dart';
 import 'package:dart_eval/dart_eval_bridge.dart';
 import 'package:dart_eval/stdlib/core.dart';
@@ -11,14 +8,6 @@ import 'package:flutter_eval/src/painting/alignment.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
-  // This is not actually a test, it just generates the flutter_eval.json file.
-  test('Generate flutter_eval.json', () {
-    final serializer = BridgeSerializer();
-    serializer.addPlugin(const FlutterEvalPlugin());
-    final output = serializer.serialize();
-    File('flutter_eval.json').writeAsStringSync(json.encode(output));
-  });
-
   test('Can extend StatelessWidget', () {
     final compiler = Compiler();
     setupFlutterForCompile(compiler);

--- a/tool/generate_bindings.dart
+++ b/tool/generate_bindings.dart
@@ -1,0 +1,15 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:dart_eval/dart_eval_bridge.dart';
+import 'package:flutter_eval/flutter_eval.dart';
+
+void main() {
+  // To properly generate the bindings, dart_eval needs Flutter context which is
+  // delivered when running Dart programs via `flutter test`,
+  // but isn't for Dart code ran via `dart run`.
+  final serializer = BridgeSerializer();
+  serializer.addPlugin(const FlutterEvalPlugin());
+  final output = serializer.serialize();
+  File('flutter_eval.json').writeAsStringSync(json.encode(output));
+}


### PR DESCRIPTION
- Moved `flutter_eval.json` file generation out of the test suite to a separate `tool/` directory
- Updated dependencies of `example/` and `examples/` apps to make `flutter pub get` work. Looks like the example projects are outdated, and cannot be run with current `flutter_eval` code, should we [regenerate those](https://github.com/ethanblake4/flutter_eval/pull/76)?
- Add GH action to generate Flutter bindings on each push to `master` branch