### PR TITLE
Support Flutter's hot reload

### DIFF
--- a/lib/src/flutter_eval.dart
+++ b/lib/src/flutter_eval.dart
@@ -588,17 +588,16 @@ Future<Uri> _writeBytesToPath(String path, Uint8List bytes) async {
 /// A widget that loads dart_eval hot-swap updates. Place this at the
 /// root of your app.
 class HotSwapLoader extends StatefulWidget {
-  HotSwapLoader(
-      {required this.uri,
-      required this.child,
-      this.strategy,
-      this.cacheFilePath,
-      this.loading,
-      this.onError,
-      this.permissions = const [],
-      super.key})
-      : assert(globalRuntime == null,
-            'A global runtime already exists. You may be trying to use multiple HotSwapLoaders in your app.');
+  const HotSwapLoader({
+    required this.uri,
+    required this.child,
+    this.strategy,
+    this.cacheFilePath,
+    this.loading,
+    this.onError,
+    this.permissions = const [],
+    super.key,
+  });
 
   final Widget child;
 
@@ -645,6 +644,20 @@ class _HotSwapLoaderState extends State<HotSwapLoader> {
   @override
   void initState() {
     super.initState();
+    assert(
+      globalRuntime == null,
+      '''
+Global runtime was already initialized. Make sure your HotSwapLoader does have
+a constant key assigned to avoid recreating the HotSwapLoader state on each hot reload, e.g.:
+
+  HotSwapLoader(
+    key: const Key('hot_swap_loader'),
+    ...
+  )
+
+Multiple HotSwapLoaders in the widget tree are not supported.
+''',
+    );
 
     try {
       if (_strategy != HotSwapStrategy.immediate) {


### PR DESCRIPTION
Currently, each full widget tree rebuild, which happens e.g. on hot reload triggers breaks this assertion:

<details>

```plain
The following assertion was thrown building MyApp(dirty):
A global runtime already exists. You may be trying to use multiple HotSwapLoaders in your app.
'package:flutter_eval/src/flutter_eval.dart':
Failed assertion: line 600 pos 16: 'globalRuntime == null'

The relevant error-causing widget was:
  MyApp
  MyApp:file:///flutter_eval/examples/code_push_app/lib/main.dart:7:16

When the exception was thrown, this was the stack:
#2      new HotSwapLoader (package:flutter_eval/src/flutter_eval.dart:600:16)
#3      MyApp.build (package:code_push_app/main.dart:17:12)
#4      StatelessElement.build (package:flutter/src/widgets/framework.dart:5550:49)
#5      ComponentElement.performRebuild (package:flutter/src/widgets/framework.dart:5480:15)
#6      Element.rebuild (package:flutter/src/widgets/framework.dart:5196:7)
#7      BuildOwner.buildScope (package:flutter/src/widgets/framework.dart:2904:19)
#8      WidgetsBinding.drawFrame (package:flutter/src/widgets/binding.dart:989:21)
#9      RendererBinding._handlePersistentFrameCallback
(package:flutter/src/rendering/binding.dart:448:5)
#10     SchedulerBinding._invokeFrameCallback (package:flutter/src/scheduler/binding.dart:1386:15)
#11     SchedulerBinding.handleDrawFrame (package:flutter/src/scheduler/binding.dart:1311:9)
#12     SchedulerBinding.scheduleWarmUpFrame.<anonymous closure>
(package:flutter/src/scheduler/binding.dart:1034:7)
#16     _RawReceivePort._handleMessage (dart:isolate-patch/isolate_patch.dart:184:12)
(elided 5 frames from class _AssertionError, class _Timer, and dart:async-patch)
```

</details>

The goal of the assertion is to prevent multiple `globalRuntime` initializations but is actually called a bit too early, at the widget creation stage. Flutter is smart enough to figure out that the state of the stateful widget doesn't have to be rebuilt if the widget itself haven't been reconfigured, so I moved the assertion to the state itself, where the actual initialization logic is happening. This allows the hot reload feature to work without affecting any internal logic of flutter/dart_eval. For more complex use-cases, an instruction of keys usage is provided with the error.

