### PR TITLE
Updates for Flutter 3.27

### DIFF
--- a/lib/flutter_eval.dart
+++ b/lib/flutter_eval.dart
@@ -188,6 +188,7 @@ class FlutterEvalPlugin implements EvalPlugin {
       $Card.$declaration,
       $Drawer.$declaration,
       $ListTile.$declaration,
+      $SwitchListTile.$declaration,
       $Image.$declaration,
       $ImageProvider.$declaration,
       $NetworkImage.$declaration,

--- a/lib/flutter_eval.dart
+++ b/lib/flutter_eval.dart
@@ -494,6 +494,10 @@ class FlutterEvalPlugin implements EvalPlugin {
           'Image.network', $Image.$network)
       ..registerBridgeFunc('package:flutter/src/widgets/image.dart',
           'Image.asset', $Image.$asset)
+      ..registerBridgeFunc('package:flutter/src/widgets/image.dart',
+          'Image.file', $Image.$file)
+      ..registerBridgeFunc('package:flutter/src/widgets/image.dart',
+          'Image.memory', $Image.$memory)
       ..registerBridgeFunc('package:flutter/src/material/list_tile.dart',
           'ListTile.', $ListTile.$new)
       ..registerBridgeFunc('package:flutter/src/material/page.dart',

--- a/lib/flutter_eval.dart
+++ b/lib/flutter_eval.dart
@@ -33,6 +33,7 @@ import 'package:flutter_eval/src/material/list_tile.dart';
 import 'package:flutter_eval/src/material/page.dart';
 import 'package:flutter_eval/src/material/scaffold.dart';
 import 'package:flutter_eval/src/material/snack_bar.dart';
+import 'package:flutter_eval/src/material/switch_list_tile.dart';
 import 'package:flutter_eval/src/material/text_button.dart';
 import 'package:flutter_eval/src/material/text_field.dart';
 import 'package:flutter_eval/src/material/text_theme.dart';
@@ -500,6 +501,8 @@ class FlutterEvalPlugin implements EvalPlugin {
           'Image.memory', $Image.$memory)
       ..registerBridgeFunc('package:flutter/src/material/list_tile.dart',
           'ListTile.', $ListTile.$new)
+      ..registerBridgeFunc('package:flutter/src/material/switch_list_tile.dart',
+          'SwitchListTile.', $SwitchListTile.$new)
       ..registerBridgeFunc('package:flutter/src/material/page.dart',
           'MaterialPageRoute.', $MaterialPageRoute.$new)
       ..registerBridgeFunc('package:flutter/src/material/scaffold.dart',

--- a/lib/src/material.dart
+++ b/lib/src/material.dart
@@ -12,6 +12,7 @@ export 'src/material/floating_action_button.dart';
 export 'src/material/icons.dart';
 export 'src/material/icon_button.dart';
 export 'src/material/list_tile.dart';
+export 'src/material/switch_list_tile.dart';
 export 'src/material/page.dart';
 export 'src/material/scaffold.dart';
 export 'src/material/snack_bar.dart';

--- a/lib/src/material/switch_list_tile.dart
+++ b/lib/src/material/switch_list_tile.dart
@@ -1,0 +1,85 @@
+import 'package:dart_eval/dart_eval_bridge.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_eval/src/foundation/key.dart';
+import 'package:flutter_eval/src/painting/edge_insets.dart';
+import 'package:flutter_eval/src/sky_engine/ui/painting.dart';
+import 'package:flutter_eval/src/widgets/framework.dart';
+
+class $SwitchListTile implements $Instance {
+  static const $type = BridgeTypeRef(BridgeTypeSpec(
+      'package:flutter/src/material/switch_list_tile.dart', 'SwitchListTile'));
+
+  static const $declaration = BridgeClassDef(
+      BridgeClassType($type,
+          isAbstract: false, $extends: $StatelessWidget$bridge.$type),
+      constructors: {
+        '': BridgeConstructorDef(BridgeFunctionDef(
+            returns: BridgeTypeAnnotation($type),
+            namedParams: [
+              BridgeParameter('key', BridgeTypeAnnotation($Key.$type), true),
+              BridgeParameter('value',
+                  BridgeTypeAnnotation(BridgeTypeRef(CoreTypes.bool)), false),
+              BridgeParameter(
+                  'onChanged',
+                  BridgeTypeAnnotation(BridgeTypeRef(CoreTypes.function),
+                      nullable: true),
+                  false),
+              BridgeParameter(
+                  'title', BridgeTypeAnnotation($Widget.$type), true),
+              BridgeParameter(
+                  'subtitle', BridgeTypeAnnotation($Widget.$type), true),
+              BridgeParameter('isThreeLine',
+                  BridgeTypeAnnotation(BridgeTypeRef(CoreTypes.bool)), true),
+              BridgeParameter('dense',
+                  BridgeTypeAnnotation(BridgeTypeRef(CoreTypes.bool)), true),
+              BridgeParameter('contentPadding',
+                  BridgeTypeAnnotation($EdgeInsetsGeometry.$type), true),
+              BridgeParameter('selected',
+                  BridgeTypeAnnotation(BridgeTypeRef(CoreTypes.bool)), true),
+              BridgeParameter(
+                  'activeColor', BridgeTypeAnnotation($Color.$type), true),
+              BridgeParameter(
+                  'secondary', BridgeTypeAnnotation($Widget.$type), true),
+            ]))
+      },
+      wrap: true);
+
+  late final _superclass = $StatelessWidget.wrap($value);
+
+  $SwitchListTile.wrap(this.$value);
+
+  @override
+  final SwitchListTile $value;
+
+  static $Value? $new(Runtime runtime, $Value? target, List<$Value?> args) {
+    return $SwitchListTile.wrap(SwitchListTile(
+      key: args[0]?.$value,
+      value: args[1]!.$value,
+      onChanged: args[2]!.$value,
+      title: args[3]?.$value,
+      subtitle: args[4]?.$value,
+      isThreeLine: args[5]?.$value ?? false,
+      dense: args[6]?.$value ?? false,
+      contentPadding: args[7]?.$value,
+      selected: args[8]?.$value ?? false,
+      activeColor: args[9]?.$value,
+      secondary: args[10]?.$value,
+    ));
+  }
+
+  @override
+  $Value? $getProperty(Runtime runtime, String identifier) {
+    return _superclass.$getProperty(runtime, identifier);
+  }
+
+  @override
+  get $reified => $value;
+
+  @override
+  int $getRuntimeType(Runtime runtime) => runtime.lookupType($type.spec!);
+
+  @override
+  void $setProperty(Runtime runtime, String identifier, $Value value) {
+    return _superclass.$setProperty(runtime, identifier, value);
+  }
+}

--- a/lib/src/material/switch_list_tile.dart
+++ b/lib/src/material/switch_list_tile.dart
@@ -1,4 +1,5 @@
 import 'package:dart_eval/dart_eval_bridge.dart';
+import 'package:dart_eval/stdlib/core.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_eval/src/foundation/key.dart';
 import 'package:flutter_eval/src/painting/edge_insets.dart';
@@ -55,7 +56,10 @@ class $SwitchListTile implements $Instance {
     return $SwitchListTile.wrap(SwitchListTile(
       key: args[0]?.$value,
       value: args[1]!.$value,
-      onChanged: args[2]!.$value,
+      onChanged: args[2] == null
+          ? null
+          : (value) =>
+              (args[2] as EvalCallable).call(runtime, null, [$bool(value)]),
       title: args[3]?.$value,
       subtitle: args[4]?.$value,
       isThreeLine: args[5]?.$value ?? false,

--- a/lib/src/sky_engine/ui/painting.dart
+++ b/lib/src/sky_engine/ui/painting.dart
@@ -1,3 +1,5 @@
+import 'dart:ui';
+
 import 'package:dart_eval/dart_eval_bridge.dart';
 import 'package:flutter/painting.dart';
 
@@ -14,6 +16,20 @@ class $Color implements Color, $Instance {
           BridgeParameter('value',
               BridgeTypeAnnotation(BridgeTypeRef(CoreTypes.int)), false)
         ])),
+        'from': BridgeConstructorDef(BridgeFunctionDef(
+            returns: BridgeTypeAnnotation($type),
+            namedParams: [
+              BridgeParameter('alpha',
+                  BridgeTypeAnnotation(BridgeTypeRef(CoreTypes.int)), false),
+              BridgeParameter('red',
+                  BridgeTypeAnnotation(BridgeTypeRef(CoreTypes.int)), false),
+              BridgeParameter('green',
+                  BridgeTypeAnnotation(BridgeTypeRef(CoreTypes.int)), false),
+              BridgeParameter('blue',
+                  BridgeTypeAnnotation(BridgeTypeRef(CoreTypes.int)), false),
+              BridgeParameter(
+                  'colorSpace', BridgeTypeAnnotation($ColorSpace.$type), true)
+            ])),
         'fromARGB': BridgeConstructorDef(
             BridgeFunctionDef(returns: BridgeTypeAnnotation($type), params: [
           BridgeParameter(
@@ -36,6 +52,17 @@ class $Color implements Color, $Instance {
           BridgeParameter(
               'o', BridgeTypeAnnotation(BridgeTypeRef(CoreTypes.int)), false)
         ]))
+      },
+      fields: {
+        'a': BridgeFieldDef(
+            BridgeTypeAnnotation(BridgeTypeRef(CoreTypes.double))),
+        'r': BridgeFieldDef(
+            BridgeTypeAnnotation(BridgeTypeRef(CoreTypes.double))),
+        'g': BridgeFieldDef(
+            BridgeTypeAnnotation(BridgeTypeRef(CoreTypes.double))),
+        'b': BridgeFieldDef(
+            BridgeTypeAnnotation(BridgeTypeRef(CoreTypes.double))),
+        'colorSpace': BridgeFieldDef(BridgeTypeAnnotation($ColorSpace.$type))
       },
       wrap: true);
 
@@ -64,6 +91,21 @@ class $Color implements Color, $Instance {
   void $setProperty(Runtime runtime, String identifier, $Value value) {
     throw UnimplementedError();
   }
+
+  @override
+  double get a => $value.a;
+
+  @override
+  double get r => $value.r;
+
+  @override
+  double get g => $value.g;
+
+  @override
+  double get b => $value.b;
+
+  @override
+  ColorSpace get colorSpace => $value.colorSpace;
 
   @override
   int get alpha => $value.alpha;
@@ -100,6 +142,21 @@ class $Color implements Color, $Instance {
 
   @override
   Color withRed(int r) => $value.withRed(r);
+
+  @override
+  Color withValues(
+          {double? alpha,
+          double? red,
+          double? green,
+          double? blue,
+          ColorSpace? colorSpace}) =>
+      $value.withValues(
+        alpha: alpha,
+        red: red,
+        green: green,
+        blue: blue,
+        colorSpace: colorSpace,
+      );
 }
 
 /// dart_eval wrapper for [Clip]
@@ -135,6 +192,38 @@ class $Clip implements $Instance {
 
   @override
   Clip get $reified => $value;
+
+  @override
+  int $getRuntimeType(Runtime runtime) => runtime.lookupType($type.spec!);
+
+  @override
+  void $setProperty(Runtime runtime, String identifier, $Value value) {
+    throw UnimplementedError();
+  }
+}
+
+class $ColorSpace implements $Instance {
+  static const $type = BridgeTypeRef(BridgeTypeSpec('dart:ui', 'ColorSpace'));
+
+  static const $declaration = BridgeEnumDef($type,
+      values: ['sRGB', 'extendedSRGB', 'displayP3'], fields: {});
+
+  static final $values = ColorSpace.values
+      .asNameMap()
+      .map((key, value) => MapEntry(key, $ColorSpace.wrap(value)));
+
+  const $ColorSpace.wrap(this.$value);
+
+  @override
+  final ColorSpace $value;
+
+  @override
+  ColorSpace get $reified => $value;
+
+  @override
+  $Value? $getProperty(Runtime runtime, String identifier) {
+    throw UnimplementedError();
+  }
 
   @override
   int $getRuntimeType(Runtime runtime) => runtime.lookupType($type.spec!);

--- a/lib/src/widgets/container.dart
+++ b/lib/src/widgets/container.dart
@@ -178,11 +178,13 @@ class $Container implements Container, $Instance {
   String toStringDeep(
           {String prefixLineOne = '',
           String? prefixOtherLines,
-          DiagnosticLevel minLevel = DiagnosticLevel.debug}) =>
+          DiagnosticLevel minLevel = DiagnosticLevel.debug,
+          int wrapWidth = 65}) =>
       $value.toStringDeep(
           prefixLineOne: prefixLineOne,
           prefixOtherLines: prefixOtherLines,
-          minLevel: minLevel);
+          minLevel: minLevel,
+          wrapWidth: wrapWidth);
 
   @override
   String toStringShallow(

--- a/lib/src/widgets/framework.dart
+++ b/lib/src/widgets/framework.dart
@@ -71,11 +71,13 @@ class $Widget implements Widget, $Instance {
   String toStringDeep(
           {String prefixLineOne = '',
           String? prefixOtherLines,
-          DiagnosticLevel minLevel = DiagnosticLevel.debug}) =>
+          DiagnosticLevel minLevel = DiagnosticLevel.debug,
+          int wrapWidth = 65}) =>
       $value.toStringDeep(
           prefixLineOne: prefixLineOne,
           prefixOtherLines: prefixOtherLines,
-          minLevel: minLevel);
+          minLevel: minLevel,
+          wrapWidth: wrapWidth);
 
   @override
   String toStringShallow(
@@ -146,11 +148,13 @@ class $StatelessWidget implements StatelessWidget, $Instance {
   String toStringDeep(
           {String prefixLineOne = '',
           String? prefixOtherLines,
-          DiagnosticLevel minLevel = DiagnosticLevel.debug}) =>
+          DiagnosticLevel minLevel = DiagnosticLevel.debug,
+          int wrapWidth = 65}) =>
       $value.toStringDeep(
           prefixLineOne: prefixLineOne,
           prefixOtherLines: prefixOtherLines,
-          minLevel: minLevel);
+          minLevel: minLevel,
+          wrapWidth: wrapWidth);
 
   @override
   String toStringShallow(
@@ -259,11 +263,13 @@ class $StatelessWidget$bridge extends StatelessWidget
   String toStringDeep(
           {String prefixLineOne = '',
           String? prefixOtherLines,
-          DiagnosticLevel minLevel = DiagnosticLevel.debug}) =>
+          DiagnosticLevel minLevel = DiagnosticLevel.debug,
+          int wrapWidth = 65}) =>
       $_invoke('toStringDeep', [
         $String(prefixLineOne),
         prefixOtherLines == null ? const $null() : $String(prefixOtherLines),
-        $DiagnosticLevel.wrap(minLevel)
+        $DiagnosticLevel.wrap(minLevel),
+        $int(wrapWidth)
       ]);
 
   @override

--- a/lib/src/widgets/image.dart
+++ b/lib/src/widgets/image.dart
@@ -184,7 +184,7 @@ class $Image implements $Instance {
       Image.network(
         args[0]!.$value,
         key: args[1]?.$value,
-        scale: args[2]?.$value,
+        scale: args[2]?.$value ?? 1.0,
         width: args[3]?.$value,
         height: args[4]?.$value,
         color: args[5]?.$value,
@@ -203,7 +203,7 @@ class $Image implements $Instance {
       Image.asset(
         args[0]!.$value,
         key: args[1]?.$value,
-        scale: args[2]?.$value,
+        scale: args[2]?.$value ?? 1.0,
         width: args[3]?.$value,
         height: args[4]?.$value,
         color: args[5]?.$value,
@@ -214,7 +214,7 @@ class $Image implements $Instance {
     );
   }
 
-  /// Instantiate a new [$Image] using [Image.asset] from [args]
+  /// Instantiate a new [$Image] using [Image.file] from [args]
   static $Value? $file(Runtime runtime, $Value? target, List<$Value?> args) {
     final file = args[0]!.$value;
     runtime.assertPermission('filesystem:read', file.path);
@@ -222,7 +222,7 @@ class $Image implements $Instance {
       Image.file(
         args[0]!.$value,
         key: args[1]?.$value,
-        scale: args[2]?.$value,
+        scale: args[2]?.$value ?? 1.0,
         width: args[3]?.$value,
         height: args[4]?.$value,
         color: args[5]?.$value,
@@ -233,13 +233,13 @@ class $Image implements $Instance {
     );
   }
 
-  /// Instantiate a new [$Image] using [Image.asset] from [args]
+  /// Instantiate a new [$Image] using [Image.memory] from [args]
   static $Value? $memory(Runtime runtime, $Value? target, List<$Value?> args) {
     return $Image.wrap(
       Image.memory(
         args[0]!.$value,
         key: args[1]?.$value,
-        scale: args[2]?.$value,
+        scale: args[2]?.$value ?? 1.0,
         width: args[3]?.$value,
         height: args[4]?.$value,
         color: args[5]?.$value,

--- a/lib/src/widgets/image.dart
+++ b/lib/src/widgets/image.dart
@@ -95,6 +95,62 @@ class $Image implements $Instance {
           ],
         ),
       ),
+      'file': BridgeConstructorDef(
+        BridgeFunctionDef(
+          returns: BridgeTypeAnnotation($type),
+          params: [
+            BridgeParameter('file',
+                BridgeTypeAnnotation(BridgeTypeRef(IoTypes.file)), false),
+          ],
+          namedParams: [
+            BridgeParameter('key', BridgeTypeAnnotation($Key.$type), true),
+            BridgeParameter('scale',
+                BridgeTypeAnnotation(BridgeTypeRef(CoreTypes.double)), true),
+            BridgeParameter('width',
+                BridgeTypeAnnotation(BridgeTypeRef(CoreTypes.double)), true),
+            BridgeParameter('height',
+                BridgeTypeAnnotation(BridgeTypeRef(CoreTypes.double)), true),
+            BridgeParameter('color', BridgeTypeAnnotation($Color.$type), true),
+            BridgeParameter('fit', BridgeTypeAnnotation($BoxFit.$type), true),
+            BridgeParameter('alignment',
+                BridgeTypeAnnotation($AlignmentGeometry.$type), true),
+            BridgeParameter(
+              'filterQuality',
+              BridgeTypeAnnotation($FilterQuality.$type),
+              true,
+            ),
+          ],
+        ),
+      ),
+      'memory': BridgeConstructorDef(
+        BridgeFunctionDef(
+          returns: BridgeTypeAnnotation($type),
+          params: [
+            BridgeParameter(
+                'bytes',
+                BridgeTypeAnnotation(BridgeTypeRef(TypedDataTypes.uint8List)),
+                false),
+          ],
+          namedParams: [
+            BridgeParameter('key', BridgeTypeAnnotation($Key.$type), true),
+            BridgeParameter('scale',
+                BridgeTypeAnnotation(BridgeTypeRef(CoreTypes.double)), true),
+            BridgeParameter('width',
+                BridgeTypeAnnotation(BridgeTypeRef(CoreTypes.double)), true),
+            BridgeParameter('height',
+                BridgeTypeAnnotation(BridgeTypeRef(CoreTypes.double)), true),
+            BridgeParameter('color', BridgeTypeAnnotation($Color.$type), true),
+            BridgeParameter('fit', BridgeTypeAnnotation($BoxFit.$type), true),
+            BridgeParameter('alignment',
+                BridgeTypeAnnotation($AlignmentGeometry.$type), true),
+            BridgeParameter(
+              'filterQuality',
+              BridgeTypeAnnotation($FilterQuality.$type),
+              true,
+            ),
+          ],
+        ),
+      ),
     },
     wrap: true,
   );
@@ -145,6 +201,42 @@ class $Image implements $Instance {
     runtime.assertPermission('asset', name);
     return $Image.wrap(
       Image.asset(
+        args[0]!.$value,
+        key: args[1]?.$value,
+        scale: args[2]?.$value,
+        width: args[3]?.$value,
+        height: args[4]?.$value,
+        color: args[5]?.$value,
+        fit: args[6]?.$value,
+        alignment: args[7]?.$value ?? Alignment.center,
+        filterQuality: args[8]?.$value ?? FilterQuality.low,
+      ),
+    );
+  }
+
+  /// Instantiate a new [$Image] using [Image.asset] from [args]
+  static $Value? $file(Runtime runtime, $Value? target, List<$Value?> args) {
+    final file = args[0]!.$value;
+    runtime.assertPermission('filesystem:read', file.path);
+    return $Image.wrap(
+      Image.file(
+        args[0]!.$value,
+        key: args[1]?.$value,
+        scale: args[2]?.$value,
+        width: args[3]?.$value,
+        height: args[4]?.$value,
+        color: args[5]?.$value,
+        fit: args[6]?.$value,
+        alignment: args[7]?.$value ?? Alignment.center,
+        filterQuality: args[8]?.$value ?? FilterQuality.low,
+      ),
+    );
+  }
+
+  /// Instantiate a new [$Image] using [Image.asset] from [args]
+  static $Value? $memory(Runtime runtime, $Value? target, List<$Value?> args) {
+    return $Image.wrap(
+      Image.memory(
         args[0]!.$value,
         key: args[1]?.$value,
         scale: args[2]?.$value,

--- a/lib/src/widgets/text.dart
+++ b/lib/src/widgets/text.dart
@@ -83,11 +83,13 @@ class $Text implements Text, $Instance {
   String toStringDeep(
           {String prefixLineOne = '',
           String? prefixOtherLines,
-          DiagnosticLevel minLevel = DiagnosticLevel.debug}) =>
+          DiagnosticLevel minLevel = DiagnosticLevel.debug,
+          int wrapWidth = 65}) =>
       $value.toStringDeep(
           prefixLineOne: prefixLineOne,
           prefixOtherLines: prefixOtherLines,
-          minLevel: minLevel);
+          minLevel: minLevel,
+          wrapWidth: wrapWidth);
 
   @override
   String toStringShallow(


### PR DESCRIPTION
There has been two changes in Flutter SDK: `Color` got fields a,rg,b; and `toStringDeep` diagnostics method got the fourth parameter, `wrapWidth`.

Alas `ColorSpace` class is exported only by `dart:ui`.

Also in this PR (for my convenience) I have fixed `Image` constructors (`Image.asset()` did not work), and added a wrapper for `SwitchListTile`.