### PR TITLE
Fix missing semanticsIdentifier on Flutter version 3.32.x

### DIFF
--- a/lib/src/widgets/text.dart
+++ b/lib/src/widgets/text.dart
@@ -44,6 +44,9 @@ class $Text implements Text, $Instance {
   final Text $value;
 
   @override
+  String? get semanticsIdentifier => this.semanticsIdentifier;
+
+  @override
   $Value? $getProperty(Runtime runtime, String identifier) {
     throw UnimplementedError();
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -25,7 +25,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  dart_eval: ^0.7.9
+  dart_eval:
+    path: ../dart_eval/
   path_provider: ^2.1.0
   http: ^1.1.0
 


### PR DESCRIPTION
### Screenshot
![image](https://github.com/user-attachments/assets/675fc652-6d5a-4dd1-a8f5-f79ef245670c)


### Error
 The non-abstract class '$Text' is missing implementations for these members:
- Text.semanticsIdentifier

### Fix:
Added the semantics identifier to the Text property