### PR TITLE
Fix build.yaml parse error during build_runner execution

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -4,3 +4,4 @@ targets:
       # Configure the builder `pkg_name|builder_name`
       # In this case, the member_count builder defined in `../example`
       dart_eval_generator|member_count:
+        enabled: true


### PR DESCRIPTION
This PR fixes a parse error in build.yaml that occurred during build_runner execution.
The issue was caused by a missing enabled: true flag in the builder configuration.

```
targets:
  $default:
    builders:
      dart_eval_generator|member_count:
        enabled: true

```
With this change, the build process now runs successfully without parse errors.