### PR TITLE
Move BuildContext to its proper location

### DIFF
--- a/lib/src/widgets/framework.dart
+++ b/lib/src/widgets/framework.dart
@@ -457,7 +457,7 @@ class $BuildContext implements BuildContext, $Instance {
 
   /// Compile-time type reference for [$BuildContext]
   static const $type = BridgeTypeRef(
-      BridgeTypeSpec('package:flutter/widgets.dart', 'BuildContext'));
+      BridgeTypeSpec('package:flutter/src/widgets/framework.dart', 'BuildContext'));
 
   /// Compile-time bridge declaration for [$BuildContext]
   static const $declaration = BridgeClassDef(


### PR DESCRIPTION
Because of this error I cannot properly use BuildContext in bindings.